### PR TITLE
Update simplehttpserver.rb

### DIFF
--- a/src/simplehttpserver.rb
+++ b/src/simplehttpserver.rb
@@ -8,6 +8,7 @@ class SimpleHTTPServer
   def start(dir, options)
     mime_types = WEBrick::HTTPUtils::DefaultMimeTypes
     mime_types.store 'js', 'application/javascript'
+    mime_types.store 'svg', 'image/svg+xml'
 
     options={
       :Port => 24680,


### PR DESCRIPTION
Adding correct MIME-TYPE for svg, so browsers like Chrome doesn't discard them.

NOTE: I haven't tested this fix live, it's based on a combination of https://github.com/mojombo/jekyll/issues/406 and https://github.com/handlino/CompassApp/issues/62

Latest build of WEBrick should solve this issue (according to http://bugs.ruby-lang.org/projects/ruby-trunk/repository/revisions/33339)

This is an issue at least on Mac OS X build of Compass.app (1.24) 

The bug can be reproduced by:

Bivald:~ niklas$ curl -I http://localhost:24680/path-to-svg.svg
HTTP/1.1 200 OK 
Etag: 65a307-3fe5-517634ed
Content-Type: application/octet-stream
Content-Length: 16357
Last-Modified: Tue, 23 Apr 2013 07:14:53 GMT
Server: WEBrick/1.3.1 (Ruby/1.8.7/2012-09-18)
Date: Tue, 23 Apr 2013 08:57:02 GMT
Connection: Keep-Alive
